### PR TITLE
:sparkles: Add exception handling

### DIFF
--- a/kaflow/applications.py
+++ b/kaflow/applications.py
@@ -35,7 +35,12 @@ from kaflow.topic import TopicProcessor
 
 if TYPE_CHECKING:
     from kaflow.serializers import Serializer
-    from kaflow.typing import ConsumerFunc, ExceptionHandlerFunc, ProducerFunc
+    from kaflow.typing import (
+        ConsumerFunc,
+        DeserializationErrorHandlerFunc,
+        ExceptionHandlerFunc,
+        ProducerFunc,
+    )
 
 
 def annotated_serializer_info(
@@ -128,8 +133,12 @@ class Kaflow:
         self._producer: AIOKafkaProducer | None = None
 
         self._topics_processors: dict[str, TopicProcessor] = {}
-        self._exception_handlers: dict[type[Exception], ExceptionHandlerFunc] = {}
         self._sink_topics: set[str] = set()
+
+        self._exception_handlers: dict[type[Exception], ExceptionHandlerFunc] = {}
+        self._deserialization_error_handler: DeserializationErrorHandlerFunc | None = (
+            None
+        )
 
         @asynccontextmanager
         async def lifespan_ctx() -> AsyncIterator[None]:
@@ -338,7 +347,9 @@ class Kaflow:
 
         return register_producer
 
-    def exception_handler(self, exception: type[Exception]) -> None:
+    def exception_handler(
+        self, exception: type[Exception]
+    ) -> Callable[[ExceptionHandlerFunc], ExceptionHandlerFunc]:
         def register_exception_handler(
             func: ExceptionHandlerFunc,
         ) -> ExceptionHandlerFunc:
@@ -347,11 +358,22 @@ class Kaflow:
 
         return register_exception_handler
 
+    def deserialization_error_handler(
+        self,
+    ) -> Callable[[DeserializationErrorHandlerFunc], DeserializationErrorHandlerFunc]:
+        def register_deserialization_error_handler(
+            func: DeserializationErrorHandlerFunc,
+        ) -> DeserializationErrorHandlerFunc:
+            self._deserialization_error_handler = func
+            return func
+
+        return register_deserialization_error_handler
+
     async def _publish(self, topic: str, value: bytes) -> None:
         if not self._producer:
             raise RuntimeError(
                 "The producer has not been started yet. You're probably seeing this"
-                f" error because `{self.__class__.__name__}.run` method has not been"
+                f" error because `{self.__class__.__name__}.start` method has not been"
                 " called yet."
             )
         await self._producer.send_and_wait(topic=topic, value=value)
@@ -360,15 +382,15 @@ class Kaflow:
         if not self._consumer:
             raise RuntimeError(
                 "The consumer has not been started yet. You're probably seeing this"
-                f" error because `{self.__class__.__name__}.run` method has not been"
+                f" error because `{self.__class__.__name__}.start` method has not been"
                 " called yet."
             )
         async for record in self._consumer:
-            topic = record.topic
-            await self._topics_processors[topic].distribute(
+            await self._topics_processors[record.topic].distribute(
                 record=record,
                 publish_fn=self._publish,
                 exception_handlers=self._exception_handlers,
+                deserialization_error_handler=self._deserialization_error_handler,
             )
 
     async def start(self) -> None:

--- a/kaflow/exceptions.py
+++ b/kaflow/exceptions.py
@@ -10,7 +10,7 @@ class KaflowException(Exception):
     ...
 
 
-class KaflowDistributeException(KaflowException):
+class KaflowDeserializationException(KaflowException):
     def __init__(self, message: str, record: ConsumerRecord) -> None:
         super().__init__(message)
         self.record = record

--- a/kaflow/typing.py
+++ b/kaflow/typing.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from typing import Awaitable, Callable, Union
 
+from aiokafka import ConsumerRecord
 from pydantic import BaseModel
 
 ConsumerFuncR = Union[BaseModel, None]
 ConsumerFunc = Callable[..., ConsumerFuncR | Awaitable[ConsumerFuncR]]
 ProducerFunc = Callable[..., BaseModel | Awaitable[BaseModel]]
 ExceptionHandlerFunc = Callable[..., None | Awaitable[None]]
+DeserializationErrorHandlerFunc = Callable[[Exception, ConsumerRecord], Awaitable[None]]


### PR DESCRIPTION
I've added two new methods to `Kaflow` class:

- `exception_handler`: which allows registering a function for handling a specific exception raised during the execution of the consumer functions.
- `deserialization_error_handler`: which allows registering a function to handle deserialization errors.