### PR TITLE
:sparkles: Update to not always serialize/create `BaseModel`

### DIFF
--- a/kaflow/_utils/asyncio.py
+++ b/kaflow/_utils/asyncio.py
@@ -3,42 +3,9 @@ from __future__ import annotations
 import asyncio
 import contextvars
 import functools
-import sys
-from typing import Any, Awaitable, Callable, Coroutine, TypeVar
+from typing import Awaitable, Callable, TypeVar
 
 from kaflow._utils.typing import ParamSpec
-
-
-async def task_group(
-    funcs: list[Callable[..., Coroutine[Any, Any, None]]], *args: Any, **kwargs: Any
-) -> None:
-    """A convenient function to run a list of coroutines. It will check the Python
-    version to see if the new `asyncio.TaskGroup` and exception groups introduced in
-    Python 3.11 are available. If they are, it will use them. Otherwise, it will use
-    the old `asyncio.gather` function.
-
-    Args:
-        funcs: A list of coroutines to run.
-        *args: Positional arguments to pass to the coroutines.
-        **kwargs: Keyword arguments to pass to the coroutines.
-
-    Raises:
-        Exception: If any of the coroutines raise an exception, it will be raised
-            here.
-    """
-    if sys.version_info < (3, 11):
-        try:
-            await asyncio.gather(*[func(*args, **kwargs) for func in funcs])
-        except Exception as e:
-            raise Exception("An exception ocurred while running coroutines") from e
-    else:
-        try:
-            async with asyncio.TaskGroup() as tg:
-                for func in funcs:
-                    tg.create_task(func(*args, **kwargs))
-        except ExceptionGroup as eg:
-            raise Exception("An exception ocurred while running coroutines") from eg
-
 
 P = ParamSpec("P")
 R = TypeVar("R")

--- a/kaflow/applications.py
+++ b/kaflow/applications.py
@@ -27,11 +27,11 @@ from kaflow._utils.inspect import (
     annotated_param_with,
     has_return_annotation,
     is_not_coroutine_function,
-    signature_contains_annotated_param_with,
 )
 from kaflow.dependencies import Scopes
 from kaflow.serializers import MESSAGE_SERIALIZER_FLAG
 from kaflow.topic import TopicProcessor
+from kaflow.typing import TopicMessage
 
 if TYPE_CHECKING:
     from kaflow.serializers import Serializer
@@ -72,6 +72,35 @@ def annotated_serializer_info(
         extra_dict = {k: extra_metadata[k] for k in extra_annotations_keys}
         return param_type, serializer, extra_dict
     return param_type, serializer, {}
+
+
+def get_message_param_info(
+    param: Any,
+) -> tuple[type[TopicMessage], type[Serializer] | None, dict[str, Any]]:
+    if param is bytes:
+        return bytes, None, {}
+
+    return annotated_serializer_info(param)
+
+
+def bytes_or_serializer_param(signature: inspect.Signature) -> inspect.Parameter | None:
+    """Get the parameter annotated with `kaflow.serializers.MESSAGE_SERIALIZER_FLAG`
+    or of type `bytes` from a function signature.
+
+    Args:
+        signature: The function signature to get the parameter from.
+
+    Returns:
+        The parameter annotated with `kaflow.serializers.MESSAGE_SERIALIZER_FLAG` or of
+        type `bytes` from the function signature, or `None` if no such parameter is
+        found.
+    """
+    for param in signature.parameters.values():
+        if param.annotation is bytes:
+            return param
+        if annotated_param_with(MESSAGE_SERIALIZER_FLAG, param.annotation):
+            return param
+    return None
 
 
 SecurityProtocol = Literal["PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"]
@@ -174,38 +203,34 @@ class Kaflow:
         self,
         topic: str,
         func: ConsumerFunc,
-        param_type: type[BaseModel],
-        deserializer: type[Serializer],
-        deserializer_extra: dict[str, Any],
-        return_type: type[BaseModel] | None,
-        serializer: type[Serializer] | None,
-        serializer_extra: dict[str, Any] | None,
+        param_type: type[TopicMessage],
+        deserializer: Serializer | None = None,
+        return_type: type[TopicMessage] | None = None,
+        serializer: Serializer | None = None,
         sink_topics: Sequence[str] | None = None,
     ) -> None:
         topic_processor = self._topics_processors.get(topic)
-        if topic_processor:
-            if (
-                topic_processor.param_type != param_type
-                or topic_processor.deserializer != deserializer
-            ):
+        if topic_processor and deserializer:
+            if type(topic_processor.deserializer) != type(deserializer):
                 self._loop.run_until_complete(self.stop())
                 raise TypeError(
-                    f"Topic '{topic}' is already registered with a different model"
-                    f" and/or deserializer. TopicProcessor: {topic_processor}."
+                    f"Topic {topic} has already been registered with a different "
+                    f"deserializer: {topic_processor.deserializer}."
                 )
-        else:
+        if not topic_processor:
             topic_processor = TopicProcessor(
                 name=topic,
-                param_type=param_type,
-                deserializer=deserializer,
-                deserializer_extra=deserializer_extra,
                 container=self._container,
+                publish_fn=self._publish,
+                exception_handlers=self._exception_handlers,
+                deserialization_error_handler=self._deserialization_error_handler,
+                deserializer=deserializer,
             )
         topic_processor.add_func(
             func=func,
+            param_type=param_type,
             return_type=return_type,
             serializer=serializer,
-            serializer_extra=serializer_extra,
             sink_topics=sink_topics,
         )
         self._topics_processors[topic] = topic_processor
@@ -246,51 +271,56 @@ class Kaflow:
     ) -> Callable[[ConsumerFunc], ConsumerFunc]:
         def register_consumer(func: ConsumerFunc) -> ConsumerFunc:
             signature = inspect.signature(func)
-            message_serializer_param = signature_contains_annotated_param_with(
-                MESSAGE_SERIALIZER_FLAG, signature
-            )
-            if not message_serializer_param:
+            message_param = bytes_or_serializer_param(signature)
+            if not message_param:
                 raise ValueError(
-                    f"'{func.__name__}' does not have a message parameter annotated"
-                    " with a serializer like `kaflow.serializers.Json`: `async def"
-                    f" {func.__name__}(message: Json[BaseModel]) -> None: ...`"
-                    " Consumers functions must have a parameter annotated with a"
-                    " serializer like `kaflow.serializers.Json` to receive the"
-                    " messages from the topic."
+                    f"'{func.__name__}' function does not have a parameter with a type"
+                    " like `bytes` or a `pydantic.BaseModel` annotated with a"
+                    " deserializer like `kaflow.serializers.Json` to receive the"
+                    f" message from the topic: `async def  {func.__name__}(message:"
+                    " Json[BaseModel]): ...`."
                 )
             return_type: Any | None = None
-            serializer: type[Serializer] | None = None
-            serializer_extra: dict[str, Any] | None = None
+            serializer_type: type[Serializer] | None = None
+            serializer_extra: dict[str, Any] = {}
             if has_return_annotation(signature):
-                if not annotated_param_with(
-                    MESSAGE_SERIALIZER_FLAG, signature.return_annotation
+                if (
+                    not annotated_param_with(
+                        MESSAGE_SERIALIZER_FLAG, signature.return_annotation
+                    )
+                    and signature.return_annotation is not bytes
                 ):
                     raise ValueError(
-                        f"`{signature.return_annotation}` cannot be used as a return"
-                        f" type for '{func.__name__}' consumer function. Consumer"
-                        " functions must return a message annotated with a serializer"
-                        " like `kaflow.serializers.Json`: `async def"
-                        f" {func.__name__}(message: Json[BaseModel]) ->"
-                        " Json[BaseModel]: ...`"
+                        f"`{signature.return_annotation.__name__}` cannot be used as a"
+                        f" return type for '{func.__name__}' consumer function."
+                        " Consumer functions must return bytes or a"
+                        " `pydantic.BaseModel` annotated with a serializer like"
+                        " `kaflow.serializers.Json` so it can be published to the"
+                        f" `sink_topics`: `async def {func.__name__}(message:"
+                        " Json[BaseModel]) -> Json[BaseModel]: ...`."
                     )
                 else:
                     (
                         return_type,
-                        serializer,
+                        serializer_type,
                         serializer_extra,
-                    ) = annotated_serializer_info(signature.return_annotation)
-            param_type, deserializer, deserializer_extra = annotated_serializer_info(
-                message_serializer_param.annotation
+                    ) = get_message_param_info(signature.return_annotation)
+            param_type, deserializer_type, deserializer_extra = get_message_param_info(
+                message_param.annotation
             )
+            deserializer = None
+            if deserializer_type:
+                deserializer = deserializer_type(**deserializer_extra)
+            serializer = None
+            if serializer_type:
+                serializer = serializer_type(**serializer_extra)
             self._add_topic_processor(
                 topic=topic,
                 func=func,
                 param_type=param_type,
                 deserializer=deserializer,
-                deserializer_extra=deserializer_extra,
                 return_type=return_type,
                 serializer=serializer,
-                serializer_extra=serializer_extra,
                 sink_topics=sink_topics,
             )
             self._sink_topics.update(sink_topics or [])
@@ -353,6 +383,8 @@ class Kaflow:
         def register_exception_handler(
             func: ExceptionHandlerFunc,
         ) -> ExceptionHandlerFunc:
+            if is_not_coroutine_function(func):
+                func = asyncify(func)
             self._exception_handlers[exception] = func
             return func
 
@@ -386,12 +418,7 @@ class Kaflow:
                 " called yet."
             )
         async for record in self._consumer:
-            await self._topics_processors[record.topic].distribute(
-                record=record,
-                publish_fn=self._publish,
-                exception_handlers=self._exception_handlers,
-                deserialization_error_handler=self._deserialization_error_handler,
-            )
+            await self._topics_processors[record.topic].distribute(record=record)
 
     async def start(self) -> None:
         self._consumer = self._create_consumer()

--- a/kaflow/topic.py
+++ b/kaflow/topic.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Coroutine, Sequence
 
 from di.dependent import Dependent
 from di.executors import AsyncExecutor
 from pydantic import BaseModel
 
-from kaflow._utils.asyncio import task_group
 from kaflow.dependencies import Scopes
 from kaflow.exceptions import KaflowDeserializationException
 
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
         ConsumerFunc,
         DeserializationErrorHandlerFunc,
         ExceptionHandlerFunc,
+        TopicMessage,
     )
 
 
@@ -30,19 +31,17 @@ class TopicProcessingFunc:
         "param_type",
         "return_type",
         "serializer",
-        "serializer_extra",
         "sink_topics",
         "executor",
     )
 
     def __init__(
         self,
-        dependent: SolvedDependent[Any],
+        dependent: SolvedDependent[TopicMessage | None],
         container: Container,
-        param_type: type[BaseModel],
-        return_type: type[BaseModel] | None = None,
-        serializer: type[Serializer] | None = None,
-        serializer_extra: dict[str, Any] | None = None,
+        param_type: type[TopicMessage],
+        return_type: type[TopicMessage] | None = None,
+        serializer: Serializer | None = None,
         sink_topics: Sequence[str] | None = None,
     ) -> None:
         self.dependent = dependent
@@ -50,30 +49,29 @@ class TopicProcessingFunc:
         self.param_type = param_type
         self.return_type = return_type
         self.serializer = serializer
-        self.serializer_extra = serializer_extra or {}
         self.sink_topics = sink_topics
         self.executor = AsyncExecutor()
 
     async def _execute_dependent(
         self,
         consumer_state: ScopeState,
-        model: BaseModel,
+        message: TopicMessage,
         exception_handlers: dict[
             type[Exception], Callable[[Exception], Awaitable[Any]]
         ],
-    ) -> Any | None:
+    ) -> TopicMessage | None:
         try:
             return await self.dependent.execute_async(
                 executor=self.executor,
                 state=consumer_state,
-                values={self.param_type: model},
+                values={self.param_type: message},
             )
         except tuple(exception_handlers.keys()) as e:
             await exception_handlers[type(e)](e)
             return None
 
-    def _validate_return_type(self, return_model: BaseModel) -> None:
-        if self.return_type and not isinstance(return_model, self.return_type):
+    def _validate_message(self, message: TopicMessage) -> None:
+        if self.return_type and not isinstance(message, self.return_type):
             func_name = self.dependent.dependency.call.__name__  # type: ignore
             raise TypeError(
                 f"Return type of `{func_name}` function is not of"
@@ -82,17 +80,17 @@ class TopicProcessingFunc:
 
     def _publish_messages(
         self,
-        return_model: BaseModel,
+        message: TopicMessage,
         publish_fn: Callable[[str, bytes], Coroutine[Any, Any, None]],
     ) -> None:
-        if self.sink_topics and self.serializer and return_model:
-            message = self.serializer.serialize(return_model, **self.serializer_extra)
+        if self.sink_topics and self.serializer and message:
+            message = self.serializer.serialize(message)
             for topic in self.sink_topics:
                 asyncio.create_task(publish_fn(topic, message))
 
     async def __call__(
         self,
-        model: BaseModel,
+        message: TopicMessage,
         state: ScopeState,
         publish_fn: Callable[[str, bytes], Coroutine[Any, Any, None]],
         exception_handlers: dict[
@@ -102,47 +100,52 @@ class TopicProcessingFunc:
         async with self.container.enter_scope(
             "consumer", state=state
         ) as consumer_state:
-            return_model = await self._execute_dependent(
+            message = await self._execute_dependent(
                 consumer_state=consumer_state,
-                model=model,
+                message=message,
                 exception_handlers=exception_handlers,
             )
-        if return_model:
-            self._validate_return_type(return_model)
-            self._publish_messages(return_model=return_model, publish_fn=publish_fn)
+        if message:
+            self._validate_message(message)
+            self._publish_messages(message, publish_fn)
+
+
+class PythonObject:
+    """Dummy class to represent a Python object."""
+
+    pass
 
 
 class TopicProcessor:
     __slots__ = (
         "name",
-        "param_type",
         "deserializer",
-        "deserializer_extra",
         "container",
-        "container_state",
+        "publish_fn",
+        "exception_handlers",
+        "deserialization_error_handler",
         "funcs",
+        "container_state",
     )
 
     def __init__(
         self,
         name: str,
-        param_type: type[BaseModel],
-        deserializer: type[Serializer],
-        deserializer_extra: dict[str, Any],
         container: Container,
+        publish_fn: Callable[[str, bytes], Coroutine[Any, Any, None]],
+        exception_handlers: dict[type[Exception], ExceptionHandlerFunc],
+        deserialization_error_handler: DeserializationErrorHandlerFunc | None = None,
+        deserializer: Serializer | None = None,
     ) -> None:
         self.name = name
-        self.param_type = param_type
         self.deserializer = deserializer
-        self.deserializer_extra = deserializer_extra
         self.container = container
-        self.funcs: list[Callable[..., Coroutine[Any, Any, None]]] = []
-
-    def __repr__(self) -> str:
-        return (
-            f"TopicProcessor(name={self.name}, model={self.param_type},"
-            f" deserializer={self.deserializer})"
-        )
+        self.publish_fn = publish_fn
+        self.exception_handlers = exception_handlers
+        self.deserialization_error_handler = deserialization_error_handler
+        self.funcs: dict[
+            type[TopicMessage], list[Callable[..., Coroutine[Any, Any, None]]]
+        ] = defaultdict(list)
 
     def prepare(self, state: ScopeState) -> None:
         self.container_state = state
@@ -150,47 +153,86 @@ class TopicProcessor:
     def add_func(
         self,
         func: ConsumerFunc,
-        return_type: type[BaseModel] | None,
-        serializer: type[Serializer] | None,
-        serializer_extra: dict[str, Any] | None,
+        param_type: type[TopicMessage],
+        return_type: type[TopicMessage] | None = None,
+        serializer: Serializer | None = None,
         sink_topics: Sequence[str] | None = None,
     ) -> None:
-        self.funcs.append(
+        key: type[TopicMessage] = PythonObject
+        if param_type is bytes or BaseModel in param_type.__bases__:
+            key = param_type
+        self.funcs[key].append(
             TopicProcessingFunc(
                 dependent=self.container.solve(
                     Dependent(func, scope="consumer"), scopes=Scopes
                 ),
                 container=self.container,
-                param_type=self.param_type,
+                param_type=param_type,
                 return_type=return_type,
                 serializer=serializer,
-                serializer_extra=serializer_extra,
                 sink_topics=sink_topics,
+            )
+        )
+
+    def _create_partial_func(
+        self,
+        message: TopicMessage,
+        func: Callable[..., Coroutine[TopicMessage | None, Any, Any]],
+    ) -> asyncio.Task[TopicMessage | None]:
+        return asyncio.create_task(
+            func(
+                message=message,
+                state=self.container_state,
+                publish_fn=self.publish_fn,
+                exception_handlers=self.exception_handlers,
             )
         )
 
     async def distribute(
         self,
         record: ConsumerRecord,
-        publish_fn: Callable[[str, bytes], Coroutine[Any, Any, None]],
-        exception_handlers: dict[type[Exception], ExceptionHandlerFunc],
-        deserialization_error_handler: DeserializationErrorHandlerFunc | None = None,
     ) -> None:
-        try:
-            raw = self.deserializer.deserialize(record.value, **self.deserializer_extra)
-            model = self.param_type(**raw)
-        except Exception as e:
-            if not deserialization_error_handler:
-                raise KaflowDeserializationException(
-                    f"Failed to deserialize message from topic `{self.name}`",
-                    record=record,
-                ) from e
-            await deserialization_error_handler(e, record)
-        else:
-            await task_group(
-                self.funcs,
-                model=model,
-                state=self.container_state,
-                publish_fn=publish_fn,
-                exception_handlers=exception_handlers,
-            )
+        deserialized = None
+        if self.deserializer:
+            try:
+                deserialized = self.deserializer.deserialize(record.value)
+            except Exception as e:
+                if not self.deserialization_error_handler:
+                    raise KaflowDeserializationException(
+                        f"Failed to deserialize message from topic `{self.name}`",
+                        record=record,
+                    ) from e
+                await self.deserialization_error_handler(e, record)
+
+        tasks = []
+        for expected_type in self.funcs:
+            if expected_type is bytes:
+                tasks.extend(
+                    [
+                        self._create_partial_func(record.value, func)
+                        for func in self.funcs[expected_type]
+                    ]
+                )
+                continue
+
+            if deserialized:
+                if expected_type is PythonObject:
+                    tasks.extend(
+                        [
+                            self._create_partial_func(deserialized, func)
+                            for func in self.funcs[expected_type]
+                        ]
+                    )
+                    continue
+
+                if BaseModel in expected_type.__bases__:
+                    model = expected_type(**deserialized)
+                    tasks.extend(
+                        [
+                            self._create_partial_func(model, func)
+                            for func in self.funcs[expected_type]
+                        ]
+                    )
+                    continue
+
+        await asyncio.gather(*tasks)

--- a/kaflow/typing.py
+++ b/kaflow/typing.py
@@ -5,8 +5,9 @@ from typing import Awaitable, Callable, Union
 from aiokafka import ConsumerRecord
 from pydantic import BaseModel
 
-ConsumerFuncR = Union[BaseModel, None]
+TopicMessage = Union[bytes, object, BaseModel]
+ConsumerFuncR = Union[TopicMessage, None]
 ConsumerFunc = Callable[..., Union[ConsumerFuncR, Awaitable[ConsumerFuncR]]]
-ProducerFunc = Callable[..., Union[BaseModel, Awaitable[BaseModel]]]
+ProducerFunc = Callable[..., Union[TopicMessage, Awaitable[TopicMessage]]]
 ExceptionHandlerFunc = Callable[..., Union[None, Awaitable[None]]]
 DeserializationErrorHandlerFunc = Callable[[Exception, ConsumerRecord], Awaitable[None]]


### PR DESCRIPTION
I've updated the logic, so using a `pydantic.BaseModel` class is not mandatory to receive the message from the topic in the consumer functions. Now, the message can be received as `bytes` or as a Python object (`dict`, `str`, etc):

```python
from typing import Any, Dict

from pydantic import BaseModel

from kaflow import Json, Kaflow


class Person(BaseModel):
    name: str
    age: int


app = Kaflow(name="test", brokers="localhost:9092")

@app.consume(topic="test_topic")
async def consume_test_topic(message: Json[Person]) -> None:
    print("Pydantic BaseModel", message)

@app.consume(topic="test_topic")
async def consume_test_topic_4(message: Json[dict]) -> None:
    print("Python dict", message)

@app.consume(topic="test_topic")
async def consume_test_topic_3(message: bytes) -> None:
    print("bytes", message)

app.run()
```